### PR TITLE
1.18 Support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/AnvilLot-Distro/pom.xml
+++ b/AnvilLot-Distro/pom.xml
@@ -83,6 +83,11 @@
             <artifactId>AnvilLot-v1_17_R1</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dev.qruet.anvillot</groupId>
+            <artifactId>AnvilLot-v1_18_R1</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/AnvilLot-Plugin/buildNumber.properties
+++ b/AnvilLot-Plugin/buildNumber.properties
@@ -1,3 +1,3 @@
 #maven.buildNumber.plugin properties file
-#Mon Oct 25 14:06:30 EDT 2021
-buildNumber=47
+#Sun Dec 05 19:34:37 CST 2021
+buildNumber=68

--- a/AnvilLot-Plugin/pom.xml
+++ b/AnvilLot-Plugin/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.17.1-R0.1-SNAPSHOT</version>
+            <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/AnvilLot-Plugin/src/main/java/dev/qruet/anvillot/nms/IContainerAnvilLot.java
+++ b/AnvilLot-Plugin/src/main/java/dev/qruet/anvillot/nms/IContainerAnvilLot.java
@@ -92,7 +92,7 @@ public interface IContainerAnvilLot {
 
         Object player = ReflectionUtils.invokeMethod("getHandle", CraftPlayer.cast(getOwner()));
         Object playerConnection = ReflectionUtils.getField(player, "b");
-        ReflectionUtils.invokeMethodWithArgs("sendPacket", playerConnection, packet);
+        ReflectionUtils.invokeMethodWithArgs(VersionHandlerNMS.MINECRAFT_BASE_VERSION > 17 ? "a" : "sendPacket", playerConnection, packet);
     }
 
     /**

--- a/AnvilLot-Plugin/src/main/java/dev/qruet/anvillot/nms/VersionHandlerNMS.java
+++ b/AnvilLot-Plugin/src/main/java/dev/qruet/anvillot/nms/VersionHandlerNMS.java
@@ -1,22 +1,24 @@
 package dev.qruet.anvillot.nms;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
 import dev.qruet.anvillot.util.ReflectionUtils;
 import net.minecraft.network.chat.ChatMessage;
 import net.minecraft.network.chat.IChatBaseComponent;
 import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.world.ITileInventory;
-import org.bukkit.Material;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.HashSet;
 
 public class VersionHandlerNMS extends VersionHandler {
 
     private static String VERSION;
+    public static final int MINECRAFT_BASE_VERSION;
 
     private static Class<?> CraftPlayer;
 
@@ -24,8 +26,11 @@ public class VersionHandlerNMS extends VersionHandler {
 
     private static Method getHandle;
 
+    private static Method openContainer117;
+
     static {
         VERSION = ReflectionUtils.getVersion();
+        MINECRAFT_BASE_VERSION = Integer.parseInt(VERSION.substring(3, VERSION.indexOf('_', 3)));
 
         CraftPlayer = ReflectionUtils.getCraftBukkitClass("entity.CraftPlayer");
 
@@ -35,6 +40,10 @@ public class VersionHandlerNMS extends VersionHandler {
         }
 
         getHandle = ReflectionUtils.getMethod(CraftPlayer, "getHandle");
+
+        if (MINECRAFT_BASE_VERSION <= 17) {
+            openContainer117 = ReflectionUtils.getMethod(EntityPlayer.class, "openContainer", ITileInventory.class);
+        }
     }
 
     public static Class<?> getLocalNMSClass(String className) throws ClassNotFoundException {
@@ -55,7 +64,11 @@ public class VersionHandlerNMS extends VersionHandler {
         try {
             EntityPlayer eplayer = (EntityPlayer) getHandle.invoke(CraftPlayer.cast(player));
             ITileInventory tileInventory = (ITileInventory) AnvilLotTileInventory.getConstructor(Block.class, IChatBaseComponent.class).newInstance(block, new ChatMessage("Repair & Name"));
-            eplayer.openContainer(tileInventory);
+            if (MINECRAFT_BASE_VERSION > 17) {
+                eplayer.a(tileInventory);
+            } else {
+                openContainer117.invoke(eplayer, tileInventory);
+            }
         } catch (IllegalAccessException | NoSuchMethodException | InstantiationException | InvocationTargetException ex) {
             ex.printStackTrace();
         }

--- a/AnvilLot-Plugin/src/main/java/dev/qruet/anvillot/util/RepairCostCalculator.java
+++ b/AnvilLot-Plugin/src/main/java/dev/qruet/anvillot/util/RepairCostCalculator.java
@@ -4,6 +4,8 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
+import dev.qruet.anvillot.nms.VersionHandlerNMS;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,7 +31,11 @@ public class RepairCostCalculator {
         }
         try {
             asNMSCopy = CraftItemStack.getMethod("asNMSCopy", org.bukkit.inventory.ItemStack.class);
-            getRepairCost = ItemStack.getMethod("getRepairCost");
+            if (VersionHandlerNMS.MINECRAFT_BASE_VERSION > 17) {
+                getRepairCost = ItemStack.getMethod("F");
+            } else {
+                getRepairCost = ItemStack.getMethod("getRepairCost");
+            }
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
         }

--- a/AnvilLot-v1_18_R1/pom.xml
+++ b/AnvilLot-v1_18_R1/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>AnvilLot</artifactId>
+        <groupId>dev.qruet.anvillot</groupId>
+        <version>3.6</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>AnvilLot-v1_18_R1</artifactId>
+    <packaging>jar</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.18-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.qruet.anvillot</groupId>
+            <artifactId>AnvilLot-Plugin</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+</project>

--- a/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/bar/v1_18_R1/ExperienceBar.java
+++ b/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/bar/v1_18_R1/ExperienceBar.java
@@ -1,0 +1,73 @@
+package dev.qruet.anvillot.bar.v1_18_R1;
+
+import dev.qruet.anvillot.AnvilLot;
+import dev.qruet.anvillot.config.GeneralPresets;
+import dev.qruet.anvillot.util.text.T;
+import org.bukkit.Bukkit;
+import org.bukkit.boss.BarFlag;
+import org.bukkit.craftbukkit.v1_18_R1.boss.CraftBossBar;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerExpChangeEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+
+public class ExperienceBar extends CraftBossBar {
+
+    private final Listener listener;
+    private Player player;
+
+    public ExperienceBar(Player player, BarFlag... flags) {
+        super("",
+                GeneralPresets.ExperienceBarPresets.COLOR,
+                GeneralPresets.ExperienceBarPresets.STYLE,
+                flags);
+        this.player = player;
+
+        update();
+
+        listener = new Listener() {
+            @EventHandler
+            public void onExpChange(PlayerExpChangeEvent e) {
+                if (!e.getPlayer().getUniqueId().equals(player.getUniqueId()))
+                    return;
+                update();
+            }
+        };
+
+        Bukkit.getPluginManager().registerEvents(listener, JavaPlugin.getPlugin(AnvilLot.class));
+    }
+
+    public void enable() {
+        super.addPlayer(player);
+    }
+
+    public void disable() {
+        super.removePlayer(player);
+    }
+
+    /**
+     * @param player
+     * @throws UnsupportedOperationException
+     */
+    @Deprecated
+    @Override
+    public void addPlayer(Player player) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void update() {
+        super.setProgress(player.getExp());
+        super.setTitle(T.C(GeneralPresets.ExperienceBarPresets.TITLE
+                .replaceAll("%level", "" +
+                        (player.getLevel() == 0 ? "" : player.getLevel()))));
+    }
+
+    public void destroy() {
+        disable();
+        HandlerList.unregisterAll(listener);
+    }
+
+}

--- a/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/bar/v1_18_R1/HardLimitBar.java
+++ b/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/bar/v1_18_R1/HardLimitBar.java
@@ -1,0 +1,57 @@
+package dev.qruet.anvillot.bar.v1_18_R1;
+
+import dev.qruet.anvillot.config.GeneralPresets;
+import dev.qruet.anvillot.nms.IContainerAnvilLot;
+import dev.qruet.anvillot.util.text.T;
+import org.bukkit.boss.BarFlag;
+import org.bukkit.craftbukkit.v1_18_R1.boss.CraftBossBar;
+
+public class HardLimitBar extends CraftBossBar {
+
+    private final IContainerAnvilLot anvil;
+    private boolean enabled;
+
+    public HardLimitBar(IContainerAnvilLot anvil, BarFlag... flags) {
+        super("",
+                GeneralPresets.TooExpensiveBarPresets.COLOR,
+                GeneralPresets.TooExpensiveBarPresets.STYLE,
+                flags);
+        this.anvil = anvil;
+        this.enabled = false;
+        super.setTitle(T.C(GeneralPresets.HardLimitBarPresets.TITLE));
+    }
+
+    /**
+     * Displays bar to assigned player
+     */
+    public void enable() {
+        if (enabled)
+            return;
+        super.addPlayer(anvil.getOwner());
+        enabled = true;
+    }
+
+    /**
+     * Removes bar from assigned player
+     */
+    public void disable() {
+        if (!enabled)
+            return;
+        super.removePlayer(anvil.getOwner());
+        enabled = false;
+    }
+
+    /**
+     * Check if bar is currently enabled
+     *
+     * @return is enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void destroy() {
+        disable();
+    }
+
+}

--- a/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/bar/v1_18_R1/TooExpensiveBar.java
+++ b/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/bar/v1_18_R1/TooExpensiveBar.java
@@ -1,0 +1,65 @@
+package dev.qruet.anvillot.bar.v1_18_R1;
+
+import dev.qruet.anvillot.config.GeneralPresets;
+import dev.qruet.anvillot.nms.IContainerAnvilLot;
+import dev.qruet.anvillot.util.text.T;
+import org.bukkit.boss.BarFlag;
+import org.bukkit.craftbukkit.v1_18_R1.boss.CraftBossBar;
+
+public class TooExpensiveBar extends CraftBossBar {
+
+    private final IContainerAnvilLot anvil;
+    private boolean enabled;
+
+    public TooExpensiveBar(IContainerAnvilLot anvil, BarFlag... flags) {
+        super("",
+                GeneralPresets.TooExpensiveBarPresets.COLOR,
+                GeneralPresets.TooExpensiveBarPresets.STYLE,
+                flags);
+        this.anvil = anvil;
+        this.enabled = false;
+        update();
+    }
+
+    /**
+     * Displays bar to assigned player
+     */
+    public void enable() {
+        if (enabled)
+            return;
+        update();
+        super.addPlayer(anvil.getOwner());
+        enabled = true;
+    }
+
+    /**
+     * Removes bar from assigned player
+     */
+    public void disable() {
+        if (!enabled)
+            return;
+        super.removePlayer(anvil.getOwner());
+        enabled = false;
+    }
+
+    /**
+     * Check if bar is currently enabled
+     *
+     * @return is enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void update() {
+        float progress = anvil.getOwner().getLevel() / (float) anvil.getCost();
+        progress = Float.isNaN(progress) ? 0 : progress;
+        super.setProgress(Math.min(1f, progress));
+        super.setTitle(T.C(GeneralPresets.TooExpensiveBarPresets.TITLE.replaceAll("%cost", "" + anvil.getCost())));
+    }
+
+    public void destroy() {
+        disable();
+    }
+
+}

--- a/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/nms/v1_18_R1/AnvilLotTileInventory.java
+++ b/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/nms/v1_18_R1/AnvilLotTileInventory.java
@@ -1,0 +1,38 @@
+package dev.qruet.anvillot.nms.v1_18_R1;
+
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_18_R1.block.CraftBlock;
+
+import net.minecraft.core.BlockPosition;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.world.ITileInventory;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.entity.player.PlayerInventory;
+import net.minecraft.world.inventory.Container;
+import net.minecraft.world.inventory.ContainerAccess;
+
+/**
+ * @author qruet
+ * @version 3.1.0-Beta-SNAPSHOT
+ */
+public class AnvilLotTileInventory implements ITileInventory {
+
+    private final IChatBaseComponent a;
+    private final BlockPosition pos;
+
+    public AnvilLotTileInventory(Block block, IChatBaseComponent var1) {
+        this.a = var1;
+        this.pos = ((CraftBlock) block).getPosition();
+    }
+
+    @Override
+    public IChatBaseComponent C_() {
+        return this.a;
+    }
+
+    @Override
+    public Container createMenu(int var1, PlayerInventory var2, EntityHuman var3) {
+        return new ContainerAnvilLot(var1, var2, ContainerAccess.a(var3.cA(), pos));
+    }
+
+}

--- a/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/nms/v1_18_R1/ContainerAnvilLot.java
+++ b/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/nms/v1_18_R1/ContainerAnvilLot.java
@@ -1,0 +1,330 @@
+package dev.qruet.anvillot.nms.v1_18_R1;
+
+import dev.qruet.anvillot.bar.v1_18_R1.ExperienceBar;
+import dev.qruet.anvillot.bar.v1_18_R1.HardLimitBar;
+import dev.qruet.anvillot.bar.v1_18_R1.TooExpensiveBar;
+import dev.qruet.anvillot.config.GeneralPresets;
+import dev.qruet.anvillot.config.assets.SoundMeta;
+import dev.qruet.anvillot.nms.IContainerAnvilLot;
+import dev.qruet.anvillot.util.L;
+import dev.qruet.anvillot.util.java.LiveReflector;
+import dev.qruet.anvillot.util.num.Int;
+import net.minecraft.network.protocol.game.PacketPlayOutGameStateChange;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.tags.TagsBlock;
+import net.minecraft.world.entity.player.EntityHuman;
+import net.minecraft.world.entity.player.PlayerInventory;
+import net.minecraft.world.inventory.Container;
+import net.minecraft.world.inventory.ContainerAccess;
+import net.minecraft.world.inventory.ContainerAnvil;
+import net.minecraft.world.inventory.InventoryClickType;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.BlockAnvil;
+import net.minecraft.world.level.block.state.IBlockData;
+import org.bukkit.Bukkit;
+import org.bukkit.boss.BarFlag;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftHumanEntity;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_18_R1.inventory.CraftItemStack;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ *
+ * @author Qruet
+ * @version 3.5.0-Beta-SNAPSHOT
+ */
+public class ContainerAnvilLot extends ContainerAnvil implements IContainerAnvilLot {
+
+    private LiveReflector<Integer> u;
+
+    private final EntityPlayer owner;
+
+    private ExperienceBar expBar;
+    private TooExpensiveBar errBar;
+    private HardLimitBar hlmBar;
+
+    private int maxCost = -1;
+    private int repairCost;
+
+    private boolean bT = false;
+
+    private final PacketPlayOutGameStateChange defaultMode;
+
+    public ContainerAnvilLot(int i, PlayerInventory playerinventory, final ContainerAccess containeraccess) {
+        super(i, playerinventory, containeraccess);
+
+        try {
+            Field u = ContainerAnvil.class.getDeclaredField("u");
+            this.u = new LiveReflector<>(this, u);
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+
+        super.maximumRepairCost = Integer.MAX_VALUE;
+
+        owner = ((CraftPlayer) playerinventory.getOwner()).getHandle();
+
+        if (GeneralPresets.EXPERIENCE_BAR_ENABLED) {
+            List<BarFlag> expFlagList = new ArrayList<>();
+            if (GeneralPresets.ExperienceBarPresets.FOG)
+                expFlagList.add(BarFlag.CREATE_FOG);
+            if (GeneralPresets.ExperienceBarPresets.DARK_SKY)
+                expFlagList.add(BarFlag.DARKEN_SKY);
+
+            expBar = new ExperienceBar(getOwner(), expFlagList.toArray(new BarFlag[0]));
+            expBar.enable();
+        }
+
+        if (GeneralPresets.TOO_EXPENSIVE_BAR_ENABLED) {
+            List<BarFlag> errFlagList = new ArrayList<>();
+            if (GeneralPresets.TooExpensiveBarPresets.FOG)
+                errFlagList.add(BarFlag.CREATE_FOG);
+            if (GeneralPresets.TooExpensiveBarPresets.DARK_SKY)
+                errFlagList.add(BarFlag.DARKEN_SKY);
+            errBar = new TooExpensiveBar(this, errFlagList.toArray(new BarFlag[0]));
+        }
+
+        if (GeneralPresets.HARD_LIMIT_BAR_ENABLED) {
+            List<BarFlag> errFlagList = new ArrayList<>();
+            if (GeneralPresets.HardLimitBarPresets.FOG)
+                errFlagList.add(BarFlag.CREATE_FOG);
+            if (GeneralPresets.HardLimitBarPresets.DARK_SKY)
+                errFlagList.add(BarFlag.DARKEN_SKY);
+            hlmBar = new HardLimitBar(this, errFlagList.toArray(new BarFlag[0]));
+        }
+
+        maxCost = GeneralPresets.DEFAULT_MAX_COST;
+
+        getOwner().getEffectivePermissions().stream().forEach(pI -> {
+            String permission = pI.getPermission();
+            if (!permission.startsWith("anvillot.limit."))
+                return;
+            this.maxCost = Int.P(permission.substring("anvillot.limit.".length()));
+        });
+
+        L.R(new Listener() {
+            @EventHandler
+            public void onDamage(EntityDamageEvent e) {
+                if (!(e.getEntity() instanceof Player))
+                    return;
+                Player player = (Player) e.getEntity();
+                if (player.getUniqueId().equals(getOwner().getUniqueId())) {
+                    player.closeInventory();
+                    HandlerList.unregisterAll(this);
+                }
+            }
+        });
+
+        maxCost = maxCost == -1 ? Integer.MAX_VALUE : maxCost;
+
+        defaultMode = new PacketPlayOutGameStateChange(PacketPlayOutGameStateChange.d, 1);
+
+        owner.w();
+
+        this.repairCost = w.b();
+    }
+
+    @Override
+    public void a(EntityHuman entityhuman, ItemStack itemstack) {
+        if (!entityhuman.fr().d) {
+            entityhuman.c(-1 * repairCost);
+            if (expBar != null)
+                expBar.update();
+        }
+
+        sendSlotUpdate(-1, new ItemStackWrapper(entityhuman.fq().l.bV.g()), -1, k());
+
+        p.a(0, ItemStack.b);
+        if (u.get() > 0) {
+            ItemStack itemstack1 = p.a(1);
+            if (!itemstack1.b() && itemstack1.I() > u.get()) {
+                itemstack1.g(u.get());
+                p.a(1, itemstack1);
+            } else {
+                p.a(1, ItemStack.b);
+            }
+        } else {
+            p.a(1, ItemStack.b);
+        }
+
+        updateRepairCost(0);
+
+        this.q.a((world, blockposition) -> {
+            IBlockData iblockdata = world.a_(blockposition);
+            if (!entityhuman.fr().d && iblockdata.a(TagsBlock.G) && entityhuman.dK().nextFloat() < 0.12F) {
+                IBlockData iblockdata1 = BlockAnvil.e(iblockdata);
+                if (iblockdata1 == null) {
+                    world.a(blockposition, false);
+                    world.c(1029, blockposition, 0);
+                    entityhuman.fq().f(itemstack);
+                } else {
+                    world.a(blockposition, iblockdata1, 2);
+                    world.c(1030, blockposition, 0);
+                }
+            } else {
+                world.c(1030, blockposition, 0);
+            }
+
+        });
+    }
+
+    @Override
+    public void transferTo(Container other, CraftHumanEntity player) {
+        if (expBar != null)
+            expBar.destroy();
+        if (errBar != null)
+            errBar.destroy();
+        if (hlmBar != null)
+            hlmBar.destroy();
+        reset();
+    }
+
+    @Override
+    public boolean a(EntityHuman entityhuman) {
+        return !this.checkReachable || this.q.<Boolean>a((world, blockposition) -> {
+            return !this.a(world.a_(blockposition)) ? false : entityhuman.h((double) blockposition.u() + 0.5D, (double) blockposition.v() + 0.5D, (double) blockposition.w() + 0.5D) <= 64.0D;
+        }, true);
+    }
+
+    @Override
+    public void a(int i, int j, InventoryClickType inventoryclicktype, EntityHuman entityhuman) {
+        if (i == 2 && ((hlmBar != null && hlmBar.isEnabled()) || (errBar != null && errBar.isEnabled()))) {
+            SoundMeta sM = GeneralPresets.DISABLED_ALERT;
+            if (sM != null) {
+                getOwner().playSound(
+                        getOwner().getLocation(),
+                        sM.getSound(),
+                        sM.getVolume(),
+                        sM.getPitch());
+            }
+        } else {
+            super.a(i, j, inventoryclicktype, entityhuman);
+        }
+    }
+
+    @Override
+    public void i() {
+        super.i();
+
+        ItemStack first = p.a(0); // retrieve item from index 0 in repair inventory
+        ItemStack second = p.a(1); // retrieve item from index 1 in repair inventory
+        ItemStack result = o.a(0); // retrieve item from index 0 in result inventory
+
+        PrepareAnvilEvent event = new PrepareAnvilEvent(getBukkitView(),
+                CraftItemStack.asCraftMirror(result).clone());
+        Bukkit.getPluginManager().callEvent(event);
+
+        result = CraftItemStack.asNMSCopy(event.getResult());
+        o.a(0, result);
+
+        owner.b.a(defaultMode);
+
+        IContainerAnvilLot.super.calculate(
+                new ItemStackWrapper(first),
+                new ItemStackWrapper(second),
+                new ItemStackWrapper(result),
+                w.b());
+
+        sendSlotUpdate(2, new ItemStackWrapper(o.a(0)), j, k());
+    }
+
+    public void updateRepairCost(int val) {
+
+        repairCost = val;
+        w.a(val);
+
+        if (expBar != null)
+            expBar.update();
+
+        if (repairCost == -1 && GeneralPresets.HARD_LIMIT) {
+            PacketPlayOutGameStateChange packet = new PacketPlayOutGameStateChange(PacketPlayOutGameStateChange.d, 3);
+            owner.b.a(packet);
+
+            if (hlmBar != null) {
+                if (!hlmBar.isEnabled())
+                    hlmBar.enable();
+            }
+
+            sendSlotUpdate(2, new ItemStackWrapper(o.a(0)), j, k());
+
+            return;
+        }
+
+        if (getOwner().getLevel() < repairCost) {
+            PacketPlayOutGameStateChange packet = new PacketPlayOutGameStateChange(PacketPlayOutGameStateChange.d, 3);
+            owner.b.a(packet);
+
+            w.a(40);
+
+            if (errBar != null) {
+                if (!errBar.isEnabled())
+                    errBar.enable();
+                else
+                    errBar.update();
+            }
+
+            sendSlotUpdate(2, new ItemStackWrapper(o.a(0)), j, k());
+
+            return;
+        }
+
+        if (hlmBar != null && hlmBar.isEnabled())
+            hlmBar.disable();
+
+        if (errBar != null && errBar.isEnabled())
+            errBar.disable();
+
+        super.d();
+
+    }
+
+    @Override
+    public void a(String s) {
+        super.a(s);
+
+        if (CraftItemStack.asBukkitCopy(p.a(0)).getType().isAir())
+            return;
+
+        if (!bT && !p.a(0).v().getString().equals(s)) {
+            bT = true;
+            updateRepairCost(repairCost + 1);
+        } else if (bT && p.a(0).v().getString().equals(s)) {
+            bT = false;
+            updateRepairCost(repairCost - 1);
+        }
+    }
+
+    public int getCost() {
+        return repairCost;
+    }
+
+    public Player getOwner() {
+        return owner.getBukkitEntity();
+    }
+
+    @Override
+    public int getMaximumCost() {
+        return maxCost;
+    }
+
+    @Override
+    public String getRenameText() {
+        return v;
+    }
+
+    private void reset() {
+        owner.b.a(new PacketPlayOutGameStateChange(PacketPlayOutGameStateChange.d, owner.d.b().a()));
+        owner.w();
+    }
+
+
+}

--- a/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/nms/v1_18_R1/ItemStackWrapper.java
+++ b/AnvilLot-v1_18_R1/src/main/java/dev/qruet/anvillot/nms/v1_18_R1/ItemStackWrapper.java
@@ -1,0 +1,48 @@
+package dev.qruet.anvillot.nms.v1_18_R1;
+
+import dev.qruet.anvillot.nms.IItemStackWrapper;
+import net.minecraft.world.item.ItemStack;
+import org.bukkit.craftbukkit.v1_18_R1.inventory.CraftItemStack;
+
+public class ItemStackWrapper implements IItemStackWrapper {
+
+    private final ItemStack itemStack;
+
+    public ItemStackWrapper(final ItemStack itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    @Override
+    public int getRepairCost() {
+        return itemStack.F();
+    }
+
+    @Override
+    public void setRepairCost(int val) {
+        itemStack.c(val);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getBukkitCopy() {
+        return CraftItemStack.asBukkitCopy(itemStack);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return itemStack.b();
+    }
+
+    @Override
+    public String getName() {
+        return itemStack.v().getString();
+    }
+
+    @Override
+    public Object getNMS() {
+        return itemStack;
+    }
+
+    public ItemStack getItemStack() {
+        return itemStack;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
     <version>3.6</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <name>AnvilLot</name>
     <description>Remove the limitations posed by default vanilla anvils and maximize their repair costs to a
         configurable amount!
@@ -22,6 +26,7 @@
         <module>AnvilLot-Distro</module>
         <module>AnvilLot-v1_16_R3</module>
         <module>AnvilLot-v1_17_R1</module>
+        <module>AnvilLot-v1_18_R1</module>
     </modules>
 
     <profiles>
@@ -36,6 +41,7 @@
                 <module>AnvilLot-v1_16_R2</module>
                 <module>AnvilLot-v1_16_R3</module>
                 <module>AnvilLot-v1_17_R1</module>
+                <module>AnvilLot-v1_18_R1</module>
                 <module>AnvilLot-Distro</module>
             </modules>
         </profile>


### PR DESCRIPTION
Closes #21.
If there's any NullPointerExceptions or NoSuchMethodExceptions, let me know. These would occur because a lot of NMS methods are no longer deobfuscated, meaning that they have different names (e.g. "a", instead of "openContainer") than before.